### PR TITLE
Add x86_64-linux platform to Gemfile.lock

### DIFF
--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -109,6 +109,10 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.15.5-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.15.5-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
+      racc (~> 1.4)
     pg (1.5.4)
     psych (5.1.1.1)
       stringio
@@ -163,6 +167,8 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
デプロイ用にAdd x86_64-linuxをgemfileに追加しました。